### PR TITLE
Remove aws provider config from module

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,10 +223,8 @@ module "aws_organizations_and_sso" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_default_tags"></a> [default\_tags](#input\_default\_tags) | Resource tags to apply across all resources | `map(string)` | <pre>{<br>  "project": "terraform-aws-organization-and-sso"<br>}</pre> | no |
 | <a name="input_enable_sso"></a> [enable\_sso](#input\_enable\_sso) | Enable AWS SSO | `bool` | `true` | no |
 | <a name="input_organization_config"></a> [organization\_config](#input\_organization\_config) | Organization configuration | `any` | <pre>{<br>  "units": {}<br>}</pre> | no |
-| <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |
 | <a name="input_sso_permission_sets"></a> [sso\_permission\_sets](#input\_sso\_permission\_sets) | AWS SSO Permission sets | `any` | `{}` | no |
 
 ## Outputs

--- a/examples/accounts-and-permission-assignments/README.md
+++ b/examples/accounts-and-permission-assignments/README.md
@@ -8,8 +8,6 @@ module "aws_organizations_and_sso" {
   source  = "chris-qa-org/organzation-and-sso/aws"
   version = "1.0.1"
 
-  region = "eu-west-2"
-
   sso_permission_sets = {
     "AdministratorAccess" = {
       description = "Administrator Access",

--- a/examples/accounts-and-permission-assignments/main.tf
+++ b/examples/accounts-and-permission-assignments/main.tf
@@ -2,8 +2,6 @@ module "aws_organizations_and_sso" {
   source  = "chris-qa-org/organzation-and-sso/aws"
   version = "1.0.1"
 
-  region = "eu-west-2"
-
   sso_permission_sets = {
     "AdministratorAccess" = {
       description      = "Administrator Access",

--- a/examples/existing-account-import/README.md
+++ b/examples/existing-account-import/README.md
@@ -8,8 +8,6 @@ module "aws_organizations_and_sso" {
   source  = "chris-qa-org/organzation-and-sso/aws"
   version = "1.0.1"
 
-  region = "eu-west-2"
-
   organization_config = {
     units = {
       "my-org-unit" = {

--- a/examples/existing-account-import/main.tf
+++ b/examples/existing-account-import/main.tf
@@ -2,8 +2,6 @@ module "aws_organizations_and_sso" {
   source  = "chris-qa-org/organzation-and-sso/aws"
   version = "1.0.1"
 
-  region = "eu-west-2"
-
   organization_config = {
     units = {
       "my-org-unit" = {

--- a/locals.tf
+++ b/locals.tf
@@ -1,7 +1,5 @@
 locals {
-  region              = var.region
   sso_permission_sets = var.sso_permission_sets
   organization_config = var.organization_config
   enable_sso          = var.enable_sso
-  default_tags        = var.default_tags
 }

--- a/provider.tf
+++ b/provider.tf
@@ -1,6 +1,0 @@
-provider "aws" {
-  region = local.region
-  default_tags {
-    tags = local.default_tags
-  }
-}

--- a/variables.tf
+++ b/variables.tf
@@ -1,8 +1,3 @@
-variable "region" {
-  description = "AWS Region"
-  type        = string
-}
-
 variable "sso_permission_sets" {
   description = "AWS SSO Permission sets"
   type        = any
@@ -22,12 +17,4 @@ variable "enable_sso" {
   description = "Enable AWS SSO"
   type        = bool
   default     = true
-}
-
-variable "default_tags" {
-  description = "Resource tags to apply across all resources"
-  type        = map(string)
-  default = {
-    project = "terraform-aws-organization-and-sso"
-  }
 }


### PR DESCRIPTION
Hi!

I came across this module and while I was trying it out I found a problem with our current Terraform configuration because the aws provider is specified inside the module, so it prevents from configuring the provider in some other way in the parent module (like assuming a role).

I believe it would be a best practice to delegate the provider configuration to the parent module that calls this module and remove the region and default_tags variables, let me know what you think!

Example usage that wasn't possible before:

```
provider "aws" {
  region = "eu-west-1"

  assume_role {
    role_arn = "arn:aws:iam::123456789:role/some-role"
  }

  default_tags {
    tags = {
      Management = "Terraform"
    }
  }
}

module "aws_organizations_and_sso" {
	source  = "chris-qa-org/organzation-and-sso/aws"
	
	.
	.
}
```
