### PR TITLE
Fix GitHub PR checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,9 @@
 name: Terraform CI
 
-on: push
+on:
+  push:
+    branches: main
+  pull_request:
 
 jobs:
   validate-terraform:


### PR DESCRIPTION
* PR's opened from untrusted forks don't run the `on: push` checks
* This changes the behaviour so that they only run on pushes to `main`,
  and also on all PR branches when authorized to