### PR TITLE
Fix SSO permissions loop

### DIFF
--- a/sso.tf
+++ b/sso.tf
@@ -39,7 +39,7 @@ data "aws_identitystore_user" "aws" {
 }
 
 resource "aws_ssoadmin_permission_set" "permission_set" {
-  for_each = local.enable_sso ? local.sso_permission_sets : {}
+  for_each = local.enable_sso ? local.sso_permission_sets : null
 
   instance_arn     = tolist(data.aws_ssoadmin_instances.ssoadmin_instances.arns)[0]
   name             = each.key


### PR DESCRIPTION
* Includes 'Inconsistent conditional result types' when the `sso_permission_sets` variable is complete
* Sets the false value to null rather than an empty object