### PR TITLE
Fix some loops only picking up one element from the list

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -2,4 +2,9 @@ locals {
   sso_permission_sets = var.sso_permission_sets
   organization_config = var.organization_config
   enable_sso          = var.enable_sso
+  accounts = flatten([
+    for unit_name, unit in local.organization_config["units"] : [
+      for account_name in keys(local.organization_config["units"][unit_name]["accounts"]) : local.organization_config["units"][unit_name]["accounts"][account_name]
+    ]
+  ])
 }

--- a/sso.tf
+++ b/sso.tf
@@ -3,11 +3,7 @@ data "aws_ssoadmin_instances" "ssoadmin_instances" {}
 data "aws_identitystore_group" "aws" {
   for_each = local.enable_sso ? toset(
     flatten([
-      for account in flatten([
-        for unit_name, unit in local.organization_config["units"] : [
-          for account_name in keys(local.organization_config["units"][unit_name]["accounts"]) : local.organization_config["units"][unit_name]["accounts"][account_name]
-        ]
-      ]) : keys(lookup(account, "group_assignments", {}))
+      for account in local.accounts : keys(lookup(account, "group_assignments", {}))
     ])
   ) : toset([])
 
@@ -22,11 +18,7 @@ data "aws_identitystore_group" "aws" {
 data "aws_identitystore_user" "aws" {
   for_each = local.enable_sso ? toset(
     flatten([
-      for account in flatten([
-        for unit_name, unit in local.organization_config["units"] : [
-          for account_name in keys(local.organization_config["units"][unit_name]["accounts"]) : local.organization_config["units"][unit_name]["accounts"][account_name]
-        ]
-      ]) : keys(lookup(account, "user_assignments", {}))
+      for account in local.accounts : keys(lookup(account, "user_assignments", {}))
     ])
   ) : toset([])
 

--- a/sso.tf
+++ b/sso.tf
@@ -68,8 +68,7 @@ resource "aws_ssoadmin_permission_set_inline_policy" "policy" {
 }
 
 resource "aws_ssoadmin_account_assignment" "group_assignment" {
-  for_each = local.enable_sso ? {
-    for assignment in flatten([
+  for_each = local.enable_sso ? merge(flatten([
       for unit_name, unit in local.organization_config["units"] : [
         for account_name in keys(local.organization_config["units"][unit_name]["accounts"]) : [
           for group_name, group_assignments in lookup(local.organization_config["units"][unit_name]["accounts"][account_name], "group_assignments", {}) : {
@@ -81,8 +80,7 @@ resource "aws_ssoadmin_account_assignment" "group_assignment" {
           }
         ]
       ]
-    ]) : keys(assignment)[0] => assignment[keys(assignment)[0]]
-  } : {}
+    ])...) : {}
 
   instance_arn       = aws_ssoadmin_permission_set.permission_set[each.value["permission_set"]].instance_arn
   permission_set_arn = aws_ssoadmin_permission_set.permission_set[each.value["permission_set"]].arn
@@ -95,8 +93,7 @@ resource "aws_ssoadmin_account_assignment" "group_assignment" {
 }
 
 resource "aws_ssoadmin_account_assignment" "user_assignment" {
-  for_each = local.enable_sso ? {
-    for assignment in flatten([
+  for_each = local.enable_sso ? merge(flatten([
       for unit_name, unit in local.organization_config["units"] : [
         for account_name in keys(local.organization_config["units"][unit_name]["accounts"]) : [
           for user_name, user_assignments in lookup(local.organization_config["units"][unit_name]["accounts"][account_name], "user_assignments", {}) : {
@@ -108,8 +105,7 @@ resource "aws_ssoadmin_account_assignment" "user_assignment" {
           }
         ]
       ]
-    ]) : keys(assignment)[0] => assignment[keys(assignment)[0]]
-  } : {}
+    ])...) : {}
 
   instance_arn       = aws_ssoadmin_permission_set.permission_set[each.value["permission_set"]].instance_arn
   permission_set_arn = aws_ssoadmin_permission_set.permission_set[each.value["permission_set"]].arn

--- a/sso.tf
+++ b/sso.tf
@@ -41,16 +41,14 @@ resource "aws_ssoadmin_permission_set" "permission_set" {
 }
 
 resource "aws_ssoadmin_managed_policy_attachment" "attachment" {
-  for_each = local.enable_sso ? {
-    for attachment in flatten([
+  for_each = local.enable_sso ? merge([
       for permission_set_name, permission_set in local.sso_permission_sets : {
-        for managed_policy_name in lookup(permission_set, "managed_policies", []) : "${permission_set_name}_${managed_policy_name}" => {
+        for managed_policy_name in permission_set["managed_policies"] : "${permission_set_name}_${managed_policy_name}" => {
           permission_set_name = permission_set_name
           managed_policy_name = managed_policy_name
         }
       }
-    ]) : keys(attachment)[0] => attachment[keys(attachment)[0]]
-  } : {}
+    ]...) : {}
 
   instance_arn       = tolist(data.aws_ssoadmin_instances.ssoadmin_instances.arns)[0]
   managed_policy_arn = "arn:aws:iam::aws:policy/${each.value["managed_policy_name"]}"


### PR DESCRIPTION
Hi!

While using this module we discovered that adding more than one element to the `managed_policies` inside the permission sets block or when adding more than one `permission_set` in the `group_assignments` or `user_assignments` had no effect as it was only picking up 1 single element from the list.

This fixes it by calling the merge function on the maps to create a list based on the suggestion from [this StackOverflow answer](https://stackoverflow.com/a/59323727)

Also a small refactor to improve code reuse using locals.