### PR TITLE
Fix depreciated identity store filter

### DIFF
--- a/sso.tf
+++ b/sso.tf
@@ -13,9 +13,11 @@ data "aws_identitystore_group" "aws" {
 
   identity_store_id = tolist(data.aws_ssoadmin_instances.ssoadmin_instances.identity_store_ids)[0]
 
-  filter {
-    attribute_path  = "DisplayName"
-    attribute_value = each.key
+  alternate_identifier {
+    unique_attribute {
+      attribute_path  = "DisplayName"
+      attribute_value = each.key
+    }
   }
 }
 
@@ -32,9 +34,11 @@ data "aws_identitystore_user" "aws" {
 
   identity_store_id = tolist(data.aws_ssoadmin_instances.ssoadmin_instances.identity_store_ids)[0]
 
-  filter {
-    attribute_path  = "UserName"
-    attribute_value = each.key
+  alternate_identifier {
+    unique_attribute {
+      attribute_path  = "UserName"
+      attribute_value = each.key
+    }
   }
 }
 


### PR DESCRIPTION
> Warning: Argument is deprecated
>
> │
> │   with module.aws_organizations_and_sso.data.aws_identitystore_group.aws,
> │   on .terraform/modules/aws_organizations_and_sso/sso.tf line 3, in data "aws_identitystore_group" "aws":
> │    3: data "aws_identitystore_group" "aws" {
> │
> │ Use the alternate_identifier attribute instead.